### PR TITLE
Fix start.sh shebang

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,4 @@
-#!bin/bash
+#!/bin/bash
 GREEN='\033[0;32m'
 while :
 do


### PR DESCRIPTION
## Summary
- fix incorrect shebang in `start.sh`

## Testing
- `npm test` *(fails: Cannot find package 'syntax-error')*

------
https://chatgpt.com/codex/tasks/task_b_683e6210ad848321bf9a76efd26f043b